### PR TITLE
Adds Mednafen PCE core to SuperGrafx system

### DIFF
--- a/init/MUOS/info/assign/NEC PC Engine SuperGrafx.ini
+++ b/init/MUOS/info/assign/NEC PC Engine SuperGrafx.ini
@@ -7,3 +7,6 @@ governor=ondemand
 
 [Beetle SuperGrafx]
 core=mednafen_supergrafx_libretro.so
+
+[Mednafen PCE]
+core=pce_libretro.so


### PR DESCRIPTION
Beetle PCE (the pce Mednafen core) supports SuperGrafx too, and is more accurate than the standard mednafen_supergrafx core (this last on is based on the pce_fast).